### PR TITLE
Replace deprecated developers.line.me URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LIFF Manager
 
-[LIFF (LINE Front-end Framework)](https://developers.line.biz/en/docs/liff/overview) Manager is an unofficial tool to manage your LIFF apps. This application is made by [M Gilang Januar](https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF) (a LINE API Expert from Indonesia). As this is an open-source project with MIT license, you can contribute by forking this repository and creating a pull request. We don't use any database or remote storage; all your credentials are stored in cookies, so it's safe and can't be taken by anyone.
+[LIFF (LINE Front-end Framework)](https://developers.line.biz/en/docs/liff/overview) Manager is an unofficial tool to manage your LIFF apps. This application is made by [M Gilang Januar](https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF) (a LINE API Expert from Indonesia). As this is an open-source project with [MIT license](./LICENSE.md), you can contribute by forking this repository and creating a pull request. We don't use any database or remote storage; all your credentials are stored in cookies, so it's safe and can't be taken by anyone.
 
 ![screenshot](./screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LIFF Manager
 
-[LIFF (LINE Front-end Framework)](https://developers.line.biz/en/docs/liff/overview) Manager is an unofficial tool for manage your LIFF apps. This application made by [M Gilang Januar](https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF) (a LINE API Expert from Indonesia). Due to this project is open source with MIT license, you can contribute by fork this repository and make a pull request. We don't use any database or storage, all your credentials are stored on cookies so it's safe and can't be taken by anyone.
+[LIFF (LINE Front-end Framework)](https://developers.line.biz/en/docs/liff/overview) Manager is an unofficial tool to manage your LIFF apps. This application is made by [M Gilang Januar](https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF) (a LINE API Expert from Indonesia). As this is an open-source project with MIT license, you can contribute by forking this repository and creating a pull request. We don't use any database or remote storage; all your credentials are stored in cookies, so it's safe and can't be taken by anyone.
 
 ![screenshot](./screenshot.png)
 
@@ -11,9 +11,10 @@
 ## Getting Started
 
  - Clone this repository
- - Install all depedencies with run `npm install`
+ - Install all depedencies by running `npm install`
  - Run `npm start` on production or `npm run serve` on development phase
- - Or just visit [https://liff-manager.mgilangjanuar.com](https://liff-manager.mgilangjanuar.com)
+ 
+ You can see the actual implementation by visiting [https://liff-manager.mgilangjanuar.com](https://liff-manager.mgilangjanuar.com)
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LIFF Manager
 
-[LIFF (LINE Front-end Framework)](https://developers.line.me/en/docs/liff/overview) Manager is an unofficial tool for manage your LIFF apps. This application made by [M Gilang Januar](https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF) (a LINE API Expert from Indonesia). Due to this project is open source with MIT license, you can contribute by fork this repository and make a pull request. We don't use any database or storage, all your credentials are stored on cookies so it's safe and can't be taken by anyone.
+[LIFF (LINE Front-end Framework)](https://developers.line.biz/en/docs/liff/overview) Manager is an unofficial tool for manage your LIFF apps. This application made by [M Gilang Januar](https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF) (a LINE API Expert from Indonesia). Due to this project is open source with MIT license, you can contribute by fork this repository and make a pull request. We don't use any database or storage, all your credentials are stored on cookies so it's safe and can't be taken by anyone.
 
 ![screenshot](./screenshot.png)
 

--- a/views/app/create.pug
+++ b/views/app/create.pug
@@ -9,7 +9,7 @@ block content
           if _err_data
             .alert.alert-danger(role="alert") Error: #{_err_data.error_description}
           p.small.text-muted Please read 
-            a(href="https://developers.line.me/en/docs/liff/overview") https://developers.line.me/en/docs/liff/overview
+            a(href="https://developers.line.biz/en/docs/liff/overview") https://developers.line.biz/en/docs/liff/overview
             |  for details.
           form(method="POST")
             .form-group.row

--- a/views/home.pug
+++ b/views/home.pug
@@ -7,7 +7,7 @@ block content
     .card-body
       h4 Description
       p.
-        <a href="https://developers.line.me/en/docs/liff/overview">LIFF (LINE Front-end Framework)</a> Manager is an unofficial tool for manage your LIFF 
+        <a href="https://developers.line.biz/en/docs/liff/overview">LIFF (LINE Front-end Framework)</a> Manager is an unofficial tool for manage your LIFF
         apps. This application made by <a href="https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF">M Gilang Januar</a> (a LINE 
         API Expert from Indonesia). Due to this project is open source with MIT license, you can contribute by fork this 
         <a href="https://github.com/mgilangjanuar/liff-manager">repository</a> and make a pull request. We don't use any database or storage, all your

--- a/views/home.pug
+++ b/views/home.pug
@@ -7,11 +7,11 @@ block content
     .card-body
       h4 Description
       p.
-        <a href="https://developers.line.biz/en/docs/liff/overview">LIFF (LINE Front-end Framework)</a> Manager is an unofficial tool for manage your LIFF
-        apps. This application made by <a href="https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF">M Gilang Januar</a> (a LINE 
-        API Expert from Indonesia). Due to this project is open source with MIT license, you can contribute by fork this 
-        <a href="https://github.com/mgilangjanuar/liff-manager">repository</a> and make a pull request. We don't use any database or storage, all your
-        credentials are stored on cookies so it's safe and can't be taken by anyone.
+        <a href="https://developers.line.biz/en/docs/liff/overview">LIFF (LINE Front-end Framework)</a> Manager is an unofficial tool to manage your LIFF
+        apps. This application is made by <a href="https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF">M Gilang Januar</a> (a LINE
+        API Expert from Indonesia).  As this is an open-source project with MIT license, you can contribute by forking this
+        <a href="https://github.com/mgilangjanuar/liff-manager">repository</a> and creating a pull request. We don't use any database or remote storage; all your
+        credentials are stored in cookies so it's safe and can't be taken by anyone.
       p.text-center.mb-0.mt-4
         img.img-fluid(src="/9ac.jpg", style="width:400px")
       

--- a/views/home.pug
+++ b/views/home.pug
@@ -9,7 +9,7 @@ block content
       p.
         <a href="https://developers.line.biz/en/docs/liff/overview">LIFF (LINE Front-end Framework)</a> Manager is an unofficial tool to manage your LIFF
         apps. This application is made by <a href="https://www.line-community.me/contributors/detail?apiId=0037F00000ZnJvgQAF">M Gilang Januar</a> (a LINE
-        API Expert from Indonesia).  As this is an open-source project with MIT license, you can contribute by forking this
+        API Expert from Indonesia).  As this is an open-source project with <a href="https://github.com/mgilangjanuar/liff-manager/blob/master/LICENSE.md">MIT license</a>, you can contribute by forking this
         <a href="https://github.com/mgilangjanuar/liff-manager">repository</a> and creating a pull request. We don't use any database or remote storage; all your
         credentials are stored in cookies so it's safe and can't be taken by anyone.
       p.text-center.mb-0.mt-4

--- a/views/register.pug
+++ b/views/register.pug
@@ -9,7 +9,7 @@ block content
           if _err_data
             .alert.alert-danger(role="alert") Error: #{_err_data.error_description}
           p.small.text-muted Get the channel ID and channel secret from your channel (read more: 
-            a(href="https://developers.line.me/en/docs/liff/getting-started") https://developers.line.me/en/docs/liff/getting-started
+            a(href="https://developers.line.biz/en/docs/liff/getting-started") https://developers.line.biz/en/docs/liff/getting-started
             | )
           form(method="POST", id="form-register")
             .form-group


### PR DESCRIPTION
## Background
As LINE has announced the deprecation of `developers.line.me` domain and introduced `developers.line.biz` as its replacement sometimes ago, a PR is needed to adjust with this change.
Along with the main intention, some fixes are also introduced to improve the documentation quality of this project.

## Changes
- [x] Replace `developers.line.me` with `developers.line.biz`
- [x] Fix grammatical mistakes in `README.md` and `views/home.pug`
- [x] Add link to MIT license when it is mentioned in both `README.md` and `views/home.pug`
